### PR TITLE
fix(gorilas.php) make aiming angle and power float variables

### DIFF
--- a/examples/games/gorilas.php
+++ b/examples/games/gorilas.php
@@ -70,12 +70,12 @@ class Player
     public Vector2 $size;
 
     public Vector2 $aimingPoint;
-    public int $aimingAngle;
-    public int $aimingPower;
+    public float $aimingAngle;
+    public float $aimingPower;
 
     public Vector2 $previousPoint;
-    public int $previousAngle;
-    public int $previousPower;
+    public float $previousAngle;
+    public float $previousPower;
 
     public Vector2 $impactPoint;
 


### PR DESCRIPTION
When running the example 'gorilas.php' a bug can be seen by aiming a negative angle.

To reproduce the bug:
1. start the game
2. point your cursor behind the player

A fatal error is raised:
> Fatal error: Uncaught TypeError: Typed property Player::$aimingAngle must be int, float used in ...../examples/games/gorilas.php on line 537

---
The fix

In order to fix this behaviour I just updated the field types to float instead of int.
