### PR TITLE
feat(Image) add ImageDrawRectangleRec binding

### DIFF
--- a/MAPPING.md
+++ b/MAPPING.md
@@ -339,7 +339,7 @@ RLAPI Vector4 *GetImageDataNormalized(Image image);                             
 | RLAPI void ImageDrawCircleV(Image *dst, Vector2 center, int radius, Color color);                                                        | TODO || 
 | RLAPI void ImageDrawRectangle(Image *dst, int posX, int posY, int width, int height, Color color);                                       | TODO || 
 | RLAPI void ImageDrawRectangleV(Image *dst, Vector2 position, Vector2 size, Color color);                                                 | TODO || 
-| RLAPI void ImageDrawRectangleRec(Image *dst, Rectangle rec, Color color);                                                                | TODO || 
+| RLAPI void ImageDrawRectangleRec(Image *dst, Rectangle rec, Color color);                                                                | raylib\Image->drawRectangleRec(Rectangle $rec, Color $color) || 
 | RLAPI void ImageDrawRectangleLines(Image *dst, Rectangle rec, int thick, Color color);                                                   | TODO || 
 | RLAPI void ImageDraw(Image *dst, Image src, Rectangle srcRec, Rectangle dstRec, Color tint);                                             | TODO ||   
 | RLAPI void ImageDraw(Image *dst, Image src, Rectangle srcRec, Rectangle dstRec);                                                         | raylib\Image->draw(Image $src, Rectangle $srcRec, Rectangle $dstRec) ||

--- a/raylib-image.c
+++ b/raylib-image.c
@@ -1026,6 +1026,29 @@ PHP_METHOD(Image, getAlphaBorder)
     RETURN_OBJ(&result->std);
 }
 
+// Draw rectangle within an image
+// RLAPI void ImageDrawRectangleRec(Image *dst, Rectangle rec, Color color);
+PHP_METHOD(Image, drawRectangleRec)
+{
+    zval *rec;
+    zval *color;
+
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_ZVAL(rec);
+        Z_PARAM_ZVAL(color);
+    ZEND_PARSE_PARAMETERS_END();
+
+    php_raylib_image_object *intern = Z_IMAGE_OBJ_P(ZEND_THIS);
+    php_raylib_rectangle_object *phpRec = Z_RECTANGLE_OBJ_P(rec);
+    php_raylib_color_object *phpColor = Z_COLOR_OBJ_P(color);
+
+    ImageDrawRectangleRec(
+        &intern->image,
+        phpRec->rectangle,
+        phpColor->color
+    );
+}
+
 const zend_function_entry php_raylib_image_methods[] = {
         PHP_ME(Image, __construct, NULL, ZEND_ACC_PUBLIC)
         PHP_ME(Image, fromFont, NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
@@ -1042,6 +1065,7 @@ const zend_function_entry php_raylib_image_methods[] = {
         PHP_ME(Image, draw, NULL, ZEND_ACC_PUBLIC)
         PHP_ME(Image, drawText, NULL, ZEND_ACC_PUBLIC)
         PHP_ME(Image, drawTextEx, NULL, ZEND_ACC_PUBLIC)
+        PHP_ME(Image, drawRectangleRec, NULL, ZEND_ACC_PUBLIC)
         PHP_ME(Image, format, NULL, ZEND_ACC_PUBLIC)
         PHP_ME(Image, alphaMask, NULL, ZEND_ACC_PUBLIC)
         PHP_ME(Image, alphaClear, NULL, ZEND_ACC_PUBLIC)


### PR DESCRIPTION
This PR implements the `ImageDrawRectangleRec` function as a member function of `raylib\Image`. It binds `Image::drawRectangleRec()` to `ImageDrawRectangleRec()`.